### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,15 @@ These functions take action based on the active project or project number in you
 * `OpenStructuralFolder()` - Opens the structural folder
 * `OpenPDF()` - Opens the most recent 01 set of drawings found in the PDF folder
 * `OpenPDFOrPDFFolder()` - Tries to open the PDF, but opens the PDF folder if it can't be found
+* `OpenStampedFolder()` - Opens the "Drawings\PDF\Stamped" (or 'Stamped (WET)') if it exists 
 * `OpenLatestPhoto()` - Opens the latest photo in the audit photos folder
 * `OpenLatestENP()` - Opens the latest ENP Excel workbook in the structural folder
 * `OpenLatestReviewPackage()` - Opens the latest PDF review package found in the structural folder
 * `OpenSolarWorks()` - Opens the SolarWorks page for the project
 * `OpenAHJPage()` - Opens the AHJ page for the project
+* `OpenPlansToStamp()` - Opens the most recent plan set in the "Drawings\PDF\Stamped" folder ready for stamping if it exists
+* `OpenCalcsToStamp()` - Opens the most recent calculations package in the "Drawings\PDF\Stamped" folder ready for stamping if it exists
+
 
 ##### Still pretty useful:
 * `ProjectFolder(projectnumber)` - returns the path to the project folder for `projectnumber`

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,6 +31,11 @@ The keys are configured as follows:
 * **Win + 4** opens PDF drawings folder
 * **Win + Ctrl + 4** opens latest 01 set or PDF drawings folder
 
+##### Stamping
+
+* **Win + Ctrl + 6** opens the plan set in the "Drawings\PDF\Stamped" folder that is ready for stamping
+* **Win + Alt + 6** opens the calculations package in the "Drawings\PDF\Stamped" folder that is ready for stamping
+
 ##### Active Project Mode
 
 * **Win + Ctrl + v** changes the active project to the number in the clipboard

--- a/examples/st_default_keys.ahk
+++ b/examples/st_default_keys.ahk
@@ -22,6 +22,10 @@ UseProjectNumberFromClipboard = 1
 #4:: OpenPDFFolder()			;Win + 4 opens PDF drawings folder
 #^4:: OpenPDFOrPDFFolder()		;Win + Ctrl + 4 opens latest 01 set or PDF drawings folder
 
+;/* STAMPING FILES */
+#^6:: OpenPlansToStamp()		;Win + Ctrl + 6 opens the latest plan set ready for stamping
+#!6:: OpenCalcsToStamp()		;Win + Alt + 6 opens the latest calculations package ready for stamping
+
 
 ;/* BECOME A PROJECT FOR ACTIVE MODE */
 #^v:: SetProjectFromClipboard()	;Win + Ctrl + v changes the active project to the number in the clipboard

--- a/st_core.ahkl
+++ b/st_core.ahkl
@@ -1,5 +1,5 @@
 GetSTCoreVersion() {
-	return 1.0402
+	return 1.05
 }
 
 ;===Default Options===

--- a/st_core.ahkl
+++ b/st_core.ahkl
@@ -3,7 +3,8 @@ GetSTCoreVersion() {
 }
 
 ;===Default Options===
-Ignore00Set = 1		;Should FindLatestReviewPackage ignore the *-00.pdf review package?
+SearchForLegacyReviewPackages = 1	;Should FindLatestReviewPackage search for review packages matching the old file naming scheme?
+Ignore00Set = 1						;Should FindLatestReviewPackage ignore the *-00.pdf review package? Only matters if looking for legacy review packages
 
 GetProjectFileLocation() {
 	return "c:\CurrentProjectNumber.txt"
@@ -315,11 +316,16 @@ FindStampedFolder(projectnumber) {
 }
 
 FindLatestReviewPackage(projectnumber) {
-	Global Ignore00Set
-	ignore := ""
-	If Ignore00Set
-		ignore := "*" . projectnumber . "-00.pdf"
-	file := FindLatestFile(StructuralFolder(projectnumber), "*JB-" . projectnumber . "*.pdf", 1, ignore)
+	Global SearchForLegacyReviewPackages
+	file := FindLatestFile(StructuralFolder(projectnumber), "*JB-" . projectnumber . "-00*_Calcs_ENP*_ALL.pdf", 1)
+	If file = "" And SearchForLegacyReviewPackages
+	{
+		Global Ignore00Set
+		ignore := ""
+		If Ignore00Set
+			ignore := "*" . projectnumber . "-00.pdf"
+		file := FindLatestFile(StructuralFolder(projectnumber), "*JB-" . projectnumber . "*.pdf", 1, ignore)
+	}
 	return file
 }
 

--- a/st_core.ahkl
+++ b/st_core.ahkl
@@ -1,5 +1,5 @@
 GetSTCoreVersion() {
-	return 1.04
+	return 1.0401
 }
 
 ;===Default Options===
@@ -172,6 +172,18 @@ OpenPDFFolder() {
 	}
 }
 
+OpenStampedFolder() {
+	projectnumber := GetProject()
+	If projectnumber <> 0
+	{
+		Location := FindStampedFolder(projectnumber)
+		If Location <> ""
+		{
+			Run %Location%
+		}
+	}
+}
+
 OpenPhotosFolder() {
 	projectnumber := GetProject()
 	If projectnumber <> 0
@@ -298,6 +310,10 @@ FindLatestPhoto(projectnumber) {
 	return file
 }
 
+FindStampedFolder(projectnumber) {
+	return FindLatestFolder(PDFFolder(projectnumber),"Stamped*",0)
+}
+
 FindLatestReviewPackage(projectnumber) {
 	Global Ignore00Set
 	ignore := ""
@@ -312,7 +328,11 @@ FindLatestENP(projectnumber) {
 	return file
 }
 
-FindLatestFile(path, pattern, recurse, ignore="") {
+FindLatestFolder(path, pattern, recurse, ignore="") {
+	return FindLatestFile(path, pattern, recurse, ignore, 2)
+}
+
+FindLatestFile(path, pattern, recurse, ignore="", foldermode=0) {
 	match := path . "\" . pattern
 	ignorematch := path . "\" . ignore
 	latestfile = ""
@@ -320,10 +340,10 @@ FindLatestFile(path, pattern, recurse, ignore="") {
 	IgnoreList =
 	If StrLen(ignore) > 0
 	{
-		Loop, %ignorematch%, 0, %recurse%
+		Loop, %ignorematch%, %foldermode%, %recurse%
 			IgnoreList = %IgnoreList%%A_LoopFileFullPath%`n
 	}
-	Loop, %match%, 0,%recurse%
+	Loop, %match%, %foldermode%,%recurse%
 		FileList = %FileList%%A_LoopFileTimeModified%`t%A_LoopFileFullPath%`n
 	Sort, FileList  ; Sort by date.
 	Loop, parse, FileList, `n

--- a/st_core.ahkl
+++ b/st_core.ahkl
@@ -1,5 +1,5 @@
 GetSTCoreVersion() {
-	return 1.0401
+	return 1.0402
 }
 
 ;===Default Options===
@@ -280,6 +280,34 @@ OpenLatestReviewPackage() {
 	return ""
 }
 
+OpenPlansToStamp() {
+	projectnumber := GetProject()
+	If projectnumber <> 0
+	{
+		rp := FindPlansToStamp(projectnumber)
+		if rp <> ""
+		{
+			Run %rp%
+			return %rp%
+		}
+	}
+	return ""
+}
+
+OpenCalcsToStamp() {
+	projectnumber := GetProject()
+	If projectnumber <> 0
+	{
+		rp := FindCalcsToStamp(projectnumber)
+		if rp <> ""
+		{
+			Run %rp%
+			return %rp%
+		}
+	}
+	return ""
+}
+
 OpenSolarWorks() {
 	projectnumber := GetProject()
 	If projectnumber <> 0
@@ -313,6 +341,22 @@ FindLatestPhoto(projectnumber) {
 
 FindStampedFolder(projectnumber) {
 	return FindLatestFolder(PDFFolder(projectnumber),"Stamped*",0)
+}
+
+FindPlansToStamp(projectnumber) { 
+	StampedFolder := FindStampedFolder(projectnumber)
+	If StampedFolder <> ""
+	{
+		return FindLatestFile(StampedFolder, "*_01*.pdf", 0)
+	}
+}
+
+FindCalcsToStamp(projectnumber) { 
+	StampedFolder := FindStampedFolder(projectnumber)
+	If StampedFolder <> ""
+	{
+		return FindLatestFile(StampedFolder, "*JB-" . projectnumber . "*.pdf", 0)
+	}
 }
 
 FindLatestReviewPackage(projectnumber) {


### PR DESCRIPTION
v1.05 changelog:
* `OpenStampedFolder()`, `FindStampedFolder(projectnumber)` added
* `OpenCalcsToStamp()`, `OpenPlansToStamp()` and supporting functions added
* Modified `FindLatestReviewPackage(projectnumber)` to comply with new file naming scheme and an option to continue searching for files matching the legacy file naming scheme
* Updated the default keys to add hotkeys for opening the Plans and Calcs ready for stamping